### PR TITLE
Add "a" to go back to insert mode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -288,6 +288,7 @@ function VimMode:bindModeKeys()
 
   ------------ exiting
   self.mode:bind({}, 'i', exit)
+  self.mode:bind({}, 'a', motions.right(self), exit)
 
   ------------ motions
   self.mode:bind({}, 'b', motions.backWord(self), nil, motions.backWord(self))


### PR DESCRIPTION
"a" in Vim goes forward one character, then drops into insert mode.
I use it all the time in Vim and was missing this in your amazing plug-in!