### PR TITLE
Use cmd+x for deletion

### DIFF
--- a/lib/operators/delete.lua
+++ b/lib/operators/delete.lua
@@ -18,14 +18,14 @@ function Delete.getModifiedBuffer(_, buffer, rangeStart, rangeFinish)
 end
 
 function Delete.modifySelection()
-  hs.eventtap.keyStroke({}, 'delete', 0)
+  hs.eventtap.keyStroke({'cmd'}, 'x', 0)
 end
 
 function Delete.getKeys()
   return {
     {
-      modifiers = {},
-      key = 'delete'
+      modifiers = {'cmd'},
+      key = 'x'
     }
   }
 end


### PR DESCRIPTION
This puts a deletion in the clipboard and also doesn't delete backwards when a selection is nil.

Closes #5 for `vim-mode-v2` branch.