### PR TITLE
Disable advanced mode for Notion.

### DIFF
--- a/lib/accessibility_buffer.lua
+++ b/lib/accessibility_buffer.lua
@@ -13,6 +13,9 @@ local bannedApps = {
   -- hasn't disabled it
   Code = true,
 
+  -- Notion's cells do not play well with advanced mode
+  Notion = true,
+
   -- Slack always returns a selection range of:
   --   { loc = 0, len = 0 }
   --


### PR DESCRIPTION
I **love** VimMode.spoon -- you've basically saved me hours of writing up a very mediocre copy of this myself.

Only issue I'm having is: when using Notion, I noticed vim mode is exited whenever I move between cell blocks in normal mode. Not great, as you usually want to go back and forth between cells. To fix this, I just added a line disabling advanced mode for Notion. Making a very stupid PR b/c I suspect other Notion users would feel this pain as well. :)