### PR TITLE
Update key sequence to have a default timeout of 140ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,15 @@ This sequence only watches for simple characters - it can't handle uppercase
 meant to handle the popularity of people binding `jj`, `jk`, or `kj` to
 entering normal mode in Vim.
 
-The sequence also times out - if you type a `j` and wait < 1sec, it will type
-the `j` for you.
+The sequence also times out by default after `140ms` - if you type a `j` and
+wait for the timeout, it will type the `j` for you. You can control the timeout like so:
+
+```lua
+-- timeout after 100ms instead. this is a nicer default for `jk`, but needs to
+-- be more like 140ms for `jj` to be caught quickly enough.
+
+vim:enterWithSequence('jk', 100)
+```
 
 If you have a sequence of `jk` and you go to type `ja` it will immediately
 pass through the `ja` keys without any latency either. I wanted this to work

--- a/lib/key_sequence.lua
+++ b/lib/key_sequence.lua
@@ -1,14 +1,14 @@
 local stringUtils = dofile(vimModeScriptPath .. "lib/utils/string_utils.lua")
 local KeySequence = {}
 
-function KeySequence:new(keys, onSequencePressed)
+function KeySequence:new(keys, maxDelayBetweenKeysMilliseconds, onSequencePressed)
   local sequence = {}
 
   setmetatable(sequence, self)
   self.__index = self
 
   sequence.keys = stringUtils.toChars(keys)
-  sequence.maxDelayBetweenKeys = 100 -- in ms
+  sequence.maxDelayBetweenKeysMilliseconds = maxDelayBetweenKeysMilliseconds or 140
   sequence.onSequencePressed = onSequencePressed
   sequence.enabled = false
   sequence.timer = nil
@@ -64,7 +64,7 @@ function KeySequence:cancelTimer()
 end
 
 function KeySequence:startTimer(fn)
-  self.timer = hs.timer.doAfter(self.maxDelayBetweenKeys / 1000, fn)
+  self.timer = hs.timer.doAfter(self.maxDelayBetweenKeysMilliseconds / 1000, fn)
 end
 
 function KeySequence:recordEvent(event)

--- a/lib/vim.lua
+++ b/lib/vim.lua
@@ -164,8 +164,10 @@ function VimMode:setVisualCaretPosition(position)
   return self
 end
 
-function VimMode:enterWithSequence(keys)
-  self.sequence = KeySequence:new(keys, function()
+-- @param keys [String] the key sequence you want, e.g. "jk"
+-- @param maxDelayBetweenKeysMilliseconds [Integer] how long to wait for the 2nd keypress
+function VimMode:enterWithSequence(keys, maxDelayBetweenKeysMilliseconds)
+  self.sequence = KeySequence:new(keys, maxDelayBetweenKeysMilliseconds, function()
     self:enter()
   end)
 


### PR DESCRIPTION
* Updates key sequence timeout from 100 to 140ms to have out of the box sane defaults
* Lets people change the sequence timeout in their config, optionally

Closes #47