### PR TITLE
Passthru key binds when disabled

### DIFF
--- a/lib/app_watcher.lua
+++ b/lib/app_watcher.lua
@@ -1,5 +1,25 @@
 local AppWatcher = {}
 
+local function debugEventType(eventType)
+  if eventType == hs.application.watcher.activated then
+    return "activated"
+  elseif eventType == hs.application.watcher.deactivated then
+    return "deactivated"
+  elseif eventType == hs.application.watcher.hidden then
+    return "hidden"
+  elseif eventType == hs.application.watcher.launched then
+    return "launched"
+  elseif eventType == hs.application.watcher.launching then
+    return "launching"
+  elseif eventType == hs.application.watcher.terminated then
+    return "terminated"
+  elseif eventType == hs.application.watcher.unhidden then
+    return "unhidden"
+  else
+    return "unknown event: " .. eventType
+  end
+end
+
 function AppWatcher:new(vim)
   local watcher = {
     -- These are the default apps that we automatically turn off Vim mode
@@ -60,13 +80,14 @@ function AppWatcher:createWatcher()
   -- build the watcher
   self.watcher =
     hs.application.watcher.new(function(applicationName, eventType, application)
-      -- App is not disabled, so we can ignore this
-      if not self.disabled[applicationName] then return end
+      local disabled = self.disabled[applicationName]
 
       if eventType == hs.application.watcher.activated then
-        self:disableVim()
-      elseif eventType == hs.application.watcher.deactivated then
-        self:enableVim()
+        if disabled then
+          self:disableVim()
+        else
+          self:enableVim()
+        end
       end
     end)
 

--- a/lib/vim.lua
+++ b/lib/vim.lua
@@ -72,6 +72,8 @@ function VimMode:new()
   vim.focusWatcher = createFocusWatcher(vim)
   vim.stateIndicator = StateIndicator:new(vim):update()
 
+  vim.enterKeyBind = nil
+
   return vim
 end
 
@@ -84,7 +86,7 @@ function VimMode:bindHotKeys(keyTable)
   if keyTable.enter then
     local enter = keyTable.enter
 
-    hs.hotkey.bind(enter[1], enter[2], function()
+    self.enterKeyBind = hs.hotkey.bind(enter[1], enter[2], function()
       self:enter()
     end)
   end
@@ -123,15 +125,18 @@ end
 function VimMode:disable()
   self.enabled = false
   self:disableSequence()
+  self:disableEnterBind()
   self:resetCommandState()
 
   return self
 end
 
 function VimMode:enable()
-  self.enabled = true
   self:resetCommandState()
   self:enableSequence()
+  self:enableEnterBind()
+
+  self.enabled = true
 
   return self
 end
@@ -187,6 +192,18 @@ function VimMode:enableKeySequence(key1, key2)
   self:enterWithSequence(key1 .. key2)
 
   return self
+end
+
+function VimMode:disableEnterBind()
+  if not self.enterKeyBind then return end
+
+  self.enterKeyBind:disable()
+end
+
+function VimMode:enableEnterBind()
+  if not self.enterKeyBind then return end
+
+  self.enterKeyBind:enable()
 end
 
 function VimMode:disableSequence()


### PR DESCRIPTION
This closes #44, so that whatever you bind `vim:enter()` to gets passed through to disabled apps.

Also the longstanding bugginess I was having with the app watcher got resolved as well, so disable/enable should consistently work now!