### PR TITLE
Fix library for new Hammerspoon versions

### DIFF
--- a/lib/accessibility_buffer.lua
+++ b/lib/accessibility_buffer.lua
@@ -66,7 +66,7 @@ function AccessibilityBuffer:getSelectionRange()
   local range = self:getCurrentElement():attributeValue("AXSelectedTextRange")
   if not range then return nil end
 
-  self.selection = Selection:new(range.loc, range.len)
+  self.selection = Selection.fromRange(range)
 
   return self.selection
 end
@@ -81,13 +81,19 @@ end
 function AccessibilityBuffer:getCurrentLineNumber()
   return self
     :getCurrentElement()
-    :lineForIndexWithParameter(self:getCurrentLineRange().location)
+    :parameterizedAttributeValue(
+      'AXLineForIndex',
+      self:getCurrentLineRange().location
+    )
 end
 
 function AccessibilityBuffer:getLineCount()
   local lineNumber = self
     :getCurrentElement()
-    :lineForIndexWithParameter(self:lastValueIndex()) or 0
+    :parameterizedAttributeValue(
+      'AXLineForIndex',
+      self:lastValueIndex()
+    ) or 0
 
   return lineNumber + 1
 end
@@ -136,7 +142,8 @@ function AccessibilityBuffer:isValid()
 end
 
 function AccessibilityBuffer:getCurrentLineNumber()
-  local axLineNumber = self:getCurrentElement():lineForIndexWithParameter(
+  local axLineNumber = self:getCurrentElement():parameterizedAttributeValue(
+    'AXLineForIndex',
     self:getCaretPosition()
   )
 
@@ -152,11 +159,11 @@ end
 function AccessibilityBuffer:getRangeForLineNumber(lineNumber)
   local range = self
     :getCurrentElement()
-    :rangeForLineWithParameter(lineNumber - 1)
+    :parameterizedAttributeValue('AXRangeForLine', lineNumber - 1)
 
   if not range then return Selection:new(0, 0) end
 
-  return Selection:new(range.loc, range.len)
+  return Selection.fromRange(range)
 end
 
 function AccessibilityBuffer.getCurrentApplication()

--- a/lib/accessibility_buffer.lua
+++ b/lib/accessibility_buffer.lua
@@ -1,4 +1,4 @@
-local ax = require("hs._asm.axuielement")
+local ax = dofile(vimModeScriptPath .. "lib/axuielement.lua")
 
 local Buffer = dofile(vimModeScriptPath .. "lib/buffer.lua")
 local Selection = dofile(vimModeScriptPath .. "lib/selection.lua")

--- a/lib/axuielement.lua
+++ b/lib/axuielement.lua
@@ -8,7 +8,6 @@ local function loadAxUiElement()
 
   -- support old versions of Hammerspoon that didn't have axuielement packaged.
   if versionUtils.hammerspoonVersionLessThan("0.9.79") then
-    hs.inspect.inspect("in here")
     -- Push ./vendor to the load path
     package.path = vimModeScriptPath .. "vendor/?/init.lua;" .. package.path
     package.cpath = vimModeScriptPath .. "vendor/?.so;" .. package.cpath

--- a/lib/axuielement.lua
+++ b/lib/axuielement.lua
@@ -1,0 +1,25 @@
+local versionUtils = dofile(vimModeScriptPath .. "lib/utils/version.lua")
+
+-- make this global so it only runs once
+vimModeAxLibrary = nil
+
+local function loadAxUiElement()
+  if vimModeAxLibrary then return vimModeAxLibrary end
+
+  -- support old versions of Hammerspoon that didn't have axuielement packaged.
+  if versionUtils.hammerspoonVersionLessThan("0.9.79") then
+    hs.inspect.inspect("in here")
+    -- Push ./vendor to the load path
+    package.path = vimModeScriptPath .. "vendor/?/init.lua;" .. package.path
+    package.cpath = vimModeScriptPath .. "vendor/?.so;" .. package.cpath
+
+    vimModeAxLibrary = require("hs._asm.axuielement")
+  else
+    -- use the built-in
+    vimModeAxLibrary = require("hs.axuielement")
+  end
+
+  return vimModeAxLibrary
+end
+
+return loadAxUiElement()

--- a/lib/focus_watcher.lua
+++ b/lib/focus_watcher.lua
@@ -1,4 +1,4 @@
-local ax = require("hs._asm.axuielement")
+local ax = dofile(vimModeScriptPath .. "lib/axuielement.lua")
 
 local registeredPids = {}
 

--- a/lib/motions/last_line.lua
+++ b/lib/motions/last_line.lua
@@ -3,7 +3,8 @@ local Motion = dofile(vimModeScriptPath .. "lib/motion.lua")
 local LastLine = Motion:new{ name = 'last_line' }
 
 function LastLine.getRange(_, buffer)
-  local start = buffer:getCurrentLineRange().position
+  local range = buffer:getCurrentLineRange()
+  local start = range.location
 
   return {
     start = start,

--- a/lib/motions/till_after_search.lua
+++ b/lib/motions/till_after_search.lua
@@ -9,8 +9,6 @@ function TillAfterSearch:getRange(buffer, ...)
 
   if not range then return nil end
 
-  vimLogger.i("backwards to " .. inspect(range))
-
   -- go right after the search result
   range.start = range.start + 1
 

--- a/lib/restricted_modal.lua
+++ b/lib/restricted_modal.lua
@@ -61,8 +61,6 @@ end
 function RestrictedModal:handleKeyPress(event)
   local character = event:getCharacters()
 
-  vimLogger.i("Pressed " .. character)
-
   if self.registeredKeys[character] then
     return false
   elseif stringUtils.isNonAlphanumeric(character) then

--- a/lib/selection.lua
+++ b/lib/selection.lua
@@ -12,6 +12,14 @@ function Selection:new(location, length)
   return selection
 end
 
+function Selection.fromRange(axRange)
+  -- Older versions of axuielement return `loc/len`
+  local location = axRange.location or axRange.loc
+  local length = axRange.length or axRange.len
+
+  return Selection:new(location, length)
+end
+
 function Selection:isSelected()
   return self.length > 0
 end

--- a/lib/state.lua
+++ b/lib/state.lua
@@ -33,7 +33,6 @@ local function createStateMachine(vim)
         vim:resetCommandState()
         vim:setNormalMode()
         vim:enterModal('normal')
-        vimLogger.i("normal enter")
       end,
       onenterInsert = function()
         vim.visualCaretPosition = nil

--- a/lib/state_indicator.lua
+++ b/lib/state_indicator.lua
@@ -1,4 +1,4 @@
-local ax = require("hs._asm.axuielement")
+local ax = dofile(vimModeScriptPath .. "lib/axuielement.lua")
 
 local axUtils = dofile(vimModeScriptPath .. "lib/utils/ax.lua")
 
@@ -41,7 +41,7 @@ local function getFocusedElementPosition()
   -- we don't want to get position for anything that isn't a text field
   if not axUtils.isTextField(currentElement) then return nil end
 
-  local position = currentElement:position()
+  local position = currentElement:attributeValue('AXPosition')
   if not position then return nil end
 
   return {

--- a/lib/strategies/accessibility_strategy.lua
+++ b/lib/strategies/accessibility_strategy.lua
@@ -1,4 +1,4 @@
-local ax = require("hs._asm.axuielement")
+local ax = dofile(vimModeScriptPath .. "lib/axuielement.lua")
 local inspect = hs.inspect.inspect
 
 local Strategy = dofile(vimModeScriptPath .. "lib/strategy.lua")

--- a/lib/strategies/accessibility_strategy.lua
+++ b/lib/strategies/accessibility_strategy.lua
@@ -25,12 +25,8 @@ function AccessibilityStrategy:fire()
   local motion = self.vim.commandState.motion
   local buffer = AccessibilityBuffer:new()
 
-  if operator then vimLogger.i("Firing operator = ", operator.name) end
-  if motion then vimLogger.i("Firing motion = ", motion.name) end
-
   -- set the caret position if we are in visual mode
   if self.vim:isMode('visual') then
-    vimLogger.i('setting caret = ' .. inspect(self.vim.visualCaretPosition))
     buffer:setCaretPosition(self.vim.visualCaretPosition)
   end
 
@@ -72,22 +68,14 @@ function AccessibilityStrategy:fire()
     local length = 0
 
     if self.vim:isMode('visual') then
-      vimLogger.i("Handling visual mode")
-
       local currentCharRange = currentRange:getCharRange()
       local caretPosition = buffer:getCaretPosition()
-
-      vimLogger.i("currentCharRange = " .. inspect(currentCharRange))
-      vimLogger.i("motionRange = " .. inspect(range))
-      vimLogger.i("caretPosition = " .. inspect(caretPosition))
 
       local result = visualUtils.getNewRange(
         currentCharRange,
         range,
         caretPosition
       )
-
-      vimLogger.i("result = " .. inspect(result))
 
       local newRange = result.range
 

--- a/lib/strategies/accessibility_strategy.lua
+++ b/lib/strategies/accessibility_strategy.lua
@@ -129,7 +129,7 @@ function AccessibilityStrategy:getSelection()
 
   if not range then return nil end
 
-  return Selection:new(range.loc, range.len)
+  return Selection.fromRange(range)
 end
 
 function AccessibilityStrategy:setSelection(location, length)
@@ -137,7 +137,7 @@ function AccessibilityStrategy:setSelection(location, length)
 end
 
 function AccessibilityStrategy:setSelectionRange(selection)
-  self:getCurrentElement():setSelectedTextRange(selection)
+  self:getCurrentElement():setAttributeValue("AXSelectedTextRange", selection)
 end
 
 function AccessibilityStrategy:getValue()

--- a/lib/utils/ax.lua
+++ b/lib/utils/ax.lua
@@ -1,4 +1,4 @@
-local ax = require("hs._asm.axuielement")
+local ax = dofile(vimModeScriptPath .. "lib/axuielement.lua")
 
 local axUtils = {}
 

--- a/lib/utils/version.lua
+++ b/lib/utils/version.lua
@@ -9,9 +9,6 @@ function versionUtils.hammerspoonVersionLessThan(compareVersion)
 
   local maxLength = math.max(#compare, #current)
 
-  logger.i(hs.inspect.inspect(compare))
-  logger.i(hs.inspect.inspect(current))
-
   for i = 1, maxLength do
     local compareVal = tonumber(compare[i]) or 0
     local currentVal = tonumber(current[i]) or 0

--- a/lib/versions.lua
+++ b/lib/versions.lua
@@ -1,0 +1,31 @@
+local fnutils = require("hs.fnutils")
+
+local versionUtils = {}
+local logger = hs.logger.new('thing', 'debug')
+
+function versionUtils.hammerspoonVersionLessThan(compareVersion)
+  local compare = fnutils.split(compareVersion, ".", nil, true)
+  local current = fnutils.split(hs.processInfo.version, ".", nil, true)
+
+  local maxLength = math.max(#compare, #current)
+
+  logger.i(hs.inspect.inspect(compare))
+  logger.i(hs.inspect.inspect(current))
+
+  for i = 1, maxLength do
+    local compareVal = tonumber(compare[i]) or 0
+    local currentVal = tonumber(current[i]) or 0
+
+    logger.i("comparing " .. compareVal .. " to " .. currentVal)
+
+    if currentVal < compareVal then
+      return true
+    elseif currentVal > compareVal then
+      return false
+    end
+  end
+
+  return false
+end
+
+return versionUtils

--- a/lib/vim.lua
+++ b/lib/vim.lua
@@ -11,12 +11,7 @@ local VimMode = {
 
 vimLogger = hs.logger.new('vim', 'debug')
 
--- Push ./vendor to the load path
-package.path = vimModeScriptPath .. "vendor/?/init.lua;" .. package.path
-package.cpath = vimModeScriptPath .. "vendor/?.so;" .. package.cpath
-
-local ax = require("hs._asm.axuielement")
-
+local ax = dofile(vimModeScriptPath .. "lib/axuielement.lua")
 dofile(vimModeScriptPath .. "lib/utils/benchmark.lua")
 
 local AccessibilityBuffer = dofile(vimModeScriptPath .. "lib/accessibility_buffer.lua")

--- a/lib/vim.lua
+++ b/lib/vim.lua
@@ -311,7 +311,6 @@ end
 function VimMode:pushDigitTo(type, digit)
   self.commandState:pushCountDigit(type, digit)
   self:updateStateIndicator()
-  vimLogger.i(inspect(self.commandState))
   return self
 end
 

--- a/lib/wait_for_char.lua
+++ b/lib/wait_for_char.lua
@@ -20,9 +20,6 @@ function WaitForChar:start()
     { hs.eventtap.event.types.keyDown },
     function(event)
       local character = event:getCharacters()
-
-      vimLogger.i("got char " .. character)
-
       local escChar = ""
 
       if character == "" or character == escChar then


### PR DESCRIPTION
Fixes #58

- [x] Write a function that checks if the Hammerspoon version is below 0.9.79
- [x] If so, load the vendored axuielement library, business as usual
- [x] Otherwise, load the bundled version that comes with the new version
- [x] Possibly hide this if/else logic in a single `axuielement.lua` file that can export either copy of the lib
- [x] Fix remaining errors