### PR TITLE
Update installer with `brew install --cask`

### DIFF
--- a/bin/installer
+++ b/bin/installer
@@ -91,7 +91,7 @@ function install_hammerspoon() {
     saysuccess "Hammerspoon is already installed!"
   else
     sayinfo "Hammerspoon not found, installing..."
-    brew cask install hammerspoon | indent
+    brew install --cask hammerspoon | indent
   fi
 }
 


### PR DESCRIPTION
Hi!

`brew cask` was [deprecated in favor of `brew` (with `--cask` when necessary)](https://brew.sh/2020/12/01/homebrew-2.6.0/), so the install-Hammerspoon-from-Homebrew step in the install script doesn't work anymore. This just fixes the line that contains the old `brew cask install hammerspoon` and replaces it with `brew install --cask hammerspoon`. You may wish to test it just to be safe — I used the original script once, so when I reran this fixed version, it didn't do everything from scratch (but it all looked good to me nonetheless).

Also — thank you so much for making this :) it's really, really awesome! 🎉 