### PR TITLE
return self in :useFallbackMode for chaining

### DIFF
--- a/lib/vim.lua
+++ b/lib/vim.lua
@@ -291,6 +291,8 @@ end
 
 function VimMode:useFallbackMode(appName)
   self.config.fallbackOnlyApps[appName] = true
+
+  return self
 end
 
 -- If we try to exit from the ContextualModal synchronously, we end


### PR DESCRIPTION
The manual installation section of README.md chains calls to `:disableForApp`, so `:useFallbackMode` ought to allow it as well.